### PR TITLE
Add methods to delete multiple tables with one API call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>fr.igred</groupId>
     <artifactId>simple-omero-client</artifactId>
-    <version>5.13.1</version>
+    <version>5.14.0</version>
     <packaging>jar</packaging>
 
     <name>Simple OMERO Client</name>

--- a/src/main/java/fr/igred/omero/Client.java
+++ b/src/main/java/fr/igred/omero/Client.java
@@ -230,9 +230,45 @@ public class Client extends Browser {
      * @throws OMEROServerError         Server error.
      * @throws InterruptedException     If block(long) does not return.
      */
+    @Deprecated
     public void delete(TableWrapper table)
     throws ServiceException, AccessException, ExecutionException, OMEROServerError, InterruptedException {
         deleteFile(table.getId());
+    }
+
+    /**
+     * Deletes a table from OMERO.
+     *
+     * @param table Table to delete.
+     *
+     * @throws ServiceException         Cannot connect to OMERO.
+     * @throws AccessException          Cannot access data.
+     * @throws ExecutionException       A Facility can't be retrieved or instantiated.
+     * @throws IllegalArgumentException ID not defined.
+     * @throws OMEROServerError         Server error.
+     * @throws InterruptedException     If block(long) does not return.
+     */
+    public void deleteTable(TableWrapper table)
+    throws ServiceException, AccessException, ExecutionException, OMEROServerError, InterruptedException {
+        deleteFile(table.getId());
+    }
+
+
+    /**
+     * Deletes a table from OMERO.
+     *
+     * @param tables List of tables to delete.
+     *
+     * @throws ServiceException         Cannot connect to OMERO.
+     * @throws AccessException          Cannot access data.
+     * @throws ExecutionException       A Facility can't be retrieved or instantiated.
+     * @throws IllegalArgumentException ID not defined.
+     * @throws OMEROServerError         Server error.
+     * @throws InterruptedException     If block(long) does not return.
+     */
+    public void deleteTables(List<TableWrapper> tables)
+    throws ServiceException, AccessException, ExecutionException, OMEROServerError, InterruptedException {
+        deleteFiles(tables.stream().map(TableWrapper::getId).collect(Collectors.toList()));
     }
 
 

--- a/src/main/java/fr/igred/omero/Client.java
+++ b/src/main/java/fr/igred/omero/Client.java
@@ -266,7 +266,7 @@ public class Client extends Browser {
      * @throws OMEROServerError         Server error.
      * @throws InterruptedException     If block(long) does not return.
      */
-    public void deleteTables(List<TableWrapper> tables)
+    public void deleteTables(Collection<? extends TableWrapper> tables)
     throws ServiceException, AccessException, ExecutionException, OMEROServerError, InterruptedException {
         deleteFiles(tables.stream().map(TableWrapper::getId).toArray(Long[]::new));
     }

--- a/src/main/java/fr/igred/omero/Client.java
+++ b/src/main/java/fr/igred/omero/Client.java
@@ -219,8 +219,6 @@ public class Client extends Browser {
 
 
     /**
-     * Deletes a table from OMERO.
-     *
      * @param table Table to delete.
      *
      * @throws ServiceException         Cannot connect to OMERO.
@@ -229,12 +227,14 @@ public class Client extends Browser {
      * @throws IllegalArgumentException ID not defined.
      * @throws OMEROServerError         Server error.
      * @throws InterruptedException     If block(long) does not return.
+     * @deprecated Deletes a table from OMERO.
      */
     @Deprecated
     public void delete(TableWrapper table)
     throws ServiceException, AccessException, ExecutionException, OMEROServerError, InterruptedException {
-        deleteFile(table.getId());
+        deleteTable(table);
     }
+
 
     /**
      * Deletes a table from OMERO.
@@ -255,7 +255,7 @@ public class Client extends Browser {
 
 
     /**
-     * Deletes a table from OMERO.
+     * Deletes tables from OMERO.
      *
      * @param tables List of tables to delete.
      *
@@ -268,7 +268,7 @@ public class Client extends Browser {
      */
     public void deleteTables(List<TableWrapper> tables)
     throws ServiceException, AccessException, ExecutionException, OMEROServerError, InterruptedException {
-        deleteFiles(tables.stream().map(TableWrapper::getId).collect(Collectors.toList()));
+        deleteFiles(tables.stream().map(TableWrapper::getId).toArray(Long[]::new));
     }
 
 

--- a/src/main/java/fr/igred/omero/GatewayWrapper.java
+++ b/src/main/java/fr/igred/omero/GatewayWrapper.java
@@ -40,7 +40,7 @@ import omero.log.SimpleLogger;
 import omero.model.FileAnnotationI;
 import omero.model.IObject;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -503,12 +503,12 @@ public abstract class GatewayWrapper {
      */
     public void deleteFile(Long id)
     throws ServiceException, AccessException, ExecutionException, OMEROServerError, InterruptedException {
-        FileAnnotationI file = new FileAnnotationI(id, false);
-        delete(file);
+        deleteFiles(id);
     }
 
+
     /**
-     * Deletes a file from OMERO
+     * Deletes files from OMERO.
      *
      * @param ids List of files IDs to delete.
      *
@@ -518,10 +518,11 @@ public abstract class GatewayWrapper {
      * @throws OMEROServerError     Server error.
      * @throws InterruptedException If block(long) does not return.
      */
-    public void deleteFiles(List<Long> ids)
+    public void deleteFiles(Long... ids)
     throws ServiceException, AccessException, ExecutionException, OMEROServerError, InterruptedException {
-        List<IObject> files = new ArrayList<>();
-        ids.forEach(e->files.add(new FileAnnotationI(e, false)));
+        List<IObject> files = Arrays.stream(ids)
+                                    .map(id -> new FileAnnotationI(id, false))
+                                    .collect(Collectors.toList());
         delete(files);
     }
 

--- a/src/main/java/fr/igred/omero/GatewayWrapper.java
+++ b/src/main/java/fr/igred/omero/GatewayWrapper.java
@@ -40,11 +40,13 @@ import omero.log.SimpleLogger;
 import omero.model.FileAnnotationI;
 import omero.model.IObject;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
 
 /**
@@ -503,6 +505,24 @@ public abstract class GatewayWrapper {
     throws ServiceException, AccessException, ExecutionException, OMEROServerError, InterruptedException {
         FileAnnotationI file = new FileAnnotationI(id, false);
         delete(file);
+    }
+
+    /**
+     * Deletes a file from OMERO
+     *
+     * @param ids List of files IDs to delete.
+     *
+     * @throws ServiceException     Cannot connect to OMERO.
+     * @throws AccessException      Cannot access data.
+     * @throws ExecutionException   A Facility can't be retrieved or instantiated.
+     * @throws OMEROServerError     Server error.
+     * @throws InterruptedException If block(long) does not return.
+     */
+    public void deleteFiles(List<Long> ids)
+    throws ServiceException, AccessException, ExecutionException, OMEROServerError, InterruptedException {
+        List<IObject> files = new ArrayList<>();
+        ids.forEach(e->files.add(new FileAnnotationI(e, false)));
+        delete(files);
     }
 
 

--- a/src/test/java/fr/igred/omero/annotations/ImageJTableTest.java
+++ b/src/test/java/fr/igred/omero/annotations/ImageJTableTest.java
@@ -154,7 +154,7 @@ class ImageJTableTest extends UserTest {
         long       roiId    = rois.get(0).getId();
         Long       fileId   = table.getFileId();
 
-        client.delete(table);
+        client.deleteTable(table);
 
         assertEquals(1, rowCount);
         assertEquals(imageId, ((DataObject) data[0][0]).getId());
@@ -188,7 +188,7 @@ class ImageJTableTest extends UserTest {
         long       roiId    = rois.get(0).getId();
         Long       fileId   = table.getFileId();
 
-        client.delete(table);
+        client.deleteTable(table);
 
         assertEquals(1, rowCount);
         assertEquals(imageId, ((DataObject) data[0][0]).getId());
@@ -220,7 +220,7 @@ class ImageJTableTest extends UserTest {
         long       roiId    = rois.get(0).getId();
         Long       fileId   = table.getFileId();
 
-        client.delete(table);
+        client.deleteTable(table);
 
         assertEquals(1, rowCount);
         assertEquals(imageId, ((DataObject) data[0][0]).getId());
@@ -250,7 +250,7 @@ class ImageJTableTest extends UserTest {
         long       roiId    = rois.get(0).getId();
         Long       fileId   = table.getFileId();
 
-        client.delete(table);
+        client.deleteTable(table);
 
         assertEquals(1, rowCount);
         assertEquals(imageId, ((DataObject) data[0][0]).getId());
@@ -278,7 +278,7 @@ class ImageJTableTest extends UserTest {
 
         Object[][] data = tables.get(0).getData();
 
-        client.delete(tables.get(0));
+        client.deleteTable(tables.get(0));
         List<TableWrapper> noTables = image.getTables(client);
 
         assertEquals(imageId, ((DataObject) data[0][0]).getId());
@@ -308,7 +308,7 @@ class ImageJTableTest extends UserTest {
 
         Object[][] data = tables.get(0).getData();
 
-        client.delete(tables.get(0));
+        client.deleteTables(tables);
         List<TableWrapper> noTables = image.getTables(client);
 
         assertEquals(imageId, ((DataObject) data[0][0]).getId());
@@ -345,7 +345,7 @@ class ImageJTableTest extends UserTest {
         long       roiId    = rois.get(0).getId();
         Long       fileId   = table.getFileId();
 
-        client.delete(table);
+        client.deleteTable(table);
 
         assertEquals(2, rowCount);
         assertEquals(imageId, ((DataObject) data[0][0]).getId());
@@ -385,7 +385,7 @@ class ImageJTableTest extends UserTest {
         Object[][] data     = table.getData();
         Long       fileId   = table.getFileId();
 
-        client.delete(table);
+        client.deleteTable(table);
 
         assertEquals(2, rowCount);
         assertEquals(imageId, ((DataObject) data[0][0]).getId());
@@ -424,7 +424,7 @@ class ImageJTableTest extends UserTest {
         Object[][] data     = table.getData();
         Long       fileId   = table.getFileId();
 
-        client.delete(table);
+        client.deleteTable(table);
 
         assertEquals(2, rowCount);
         assertEquals(imageId, ((DataObject) data[0][0]).getId());
@@ -477,7 +477,7 @@ class ImageJTableTest extends UserTest {
         Object[][] data     = table.getData();
         Long       fileId   = table.getFileId();
 
-        client.delete(table);
+        client.deleteTable(table);
 
         assertEquals(2, rowCount);
         assertEquals(imageId, ((DataObject) data[0][0]).getId());
@@ -535,7 +535,7 @@ class ImageJTableTest extends UserTest {
         Object[][] data     = table.getData();
         Long       fileId   = table.getFileId();
 
-        client.delete(table);
+        client.deleteTable(table);
 
         assertEquals(2, rowCount);
         assertEquals(imageId, ((DataObject) data[0][0]).getId());
@@ -596,7 +596,7 @@ class ImageJTableTest extends UserTest {
         Object[][] data     = table.getData();
         Long       fileId   = table.getFileId();
 
-        client.delete(table);
+        client.deleteTable(table);
 
         assertEquals(1, rowCount);
         assertEquals(imageId, ((DataObject) data[0][0]).getId());
@@ -627,7 +627,7 @@ class ImageJTableTest extends UserTest {
         Object[][] data     = table.getData();
         Long       fileId   = table.getFileId();
 
-        client.delete(table);
+        client.deleteTable(table);
 
         assertEquals(1, rowCount);
         assertEquals(imageId, ((DataObject) data[0][0]).getId());
@@ -663,7 +663,7 @@ class ImageJTableTest extends UserTest {
         assertEquals(1, tables.size());
         assertEquals(2, tables.get(0).getRowCount());
 
-        client.delete(tables.get(0));
+        client.deleteTables(tables);
         List<TableWrapper> noTables = image.getTables(client);
 
         assertEquals(imageId, ((DataObject) data[0][0]).getId());

--- a/src/test/java/fr/igred/omero/annotations/TableTest.java
+++ b/src/test/java/fr/igred/omero/annotations/TableTest.java
@@ -66,7 +66,7 @@ class TableTest extends UserTest {
         dataset.addTable(client, table);
 
         List<TableWrapper> tables = dataset.getTables(client);
-        client.delete(tables.get(0));
+        client.deleteTables(tables);
         List<TableWrapper> noTables = dataset.getTables(client);
 
         assertEquals(1, tables.size());


### PR DESCRIPTION
Hello @ppouchin, 

In order to minimize the numbre of API calls, I add some methods to be able to delete multiple tables with one API call.
I wasn't able to find a way to do it with the existing methods. That's why I added them.

Rémy.