### PR TITLE
set plane coordinates

### DIFF
--- a/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
@@ -153,7 +153,10 @@ public abstract class GenericShapeWrapper<T extends ShapeData> extends Annotatab
 
         // Adjust coordinates if ROI does not have hyperstack positions
         if (!ijRoi.hasHyperStackPosition()) {
-            ImagePlus imp = ij.WindowManager.getImage(ijRoi.getImageID()); //ijRoi.getImage() returns null
+            ImagePlus imp = ijRoi.getImage();
+            if (imp == null) {
+                imp = ij.WindowManager.getImage(ijRoi.getImageID());
+            }
             if (imp != null) {
                 int stackSize = imp.getStackSize();
                 int imageC    = imp.getNChannels();

--- a/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
@@ -136,9 +136,6 @@ public abstract class GenericShapeWrapper<T extends ShapeData> extends Annotatab
      * @param ijRoi An ImageJ Roi.
      */
     protected void copyFromIJRoi(ij.gui.Roi ijRoi) {
-        data.setC(Math.max(-1, ijRoi.getCPosition() - 1));
-        data.setZ(Math.max(-1, ijRoi.getZPosition() - 1));
-        data.setT(Math.max(-1, ijRoi.getTPosition() - 1));
         LengthI size          = new LengthI(ijRoi.getStrokeWidth(), UnitsLength.POINT);
         Color   defaultStroke = Optional.ofNullable(Roi.getColor()).orElse(Color.YELLOW);
         Color   defaultFill   = Optional.ofNullable(Roi.getDefaultFillColor()).orElse(TRANSPARENT);
@@ -147,6 +144,34 @@ public abstract class GenericShapeWrapper<T extends ShapeData> extends Annotatab
         data.getShapeSettings().setStrokeWidth(size);
         data.getShapeSettings().setStroke(stroke);
         data.getShapeSettings().setFill(fill);
+        // Set the plane 
+        int pos = ijRoi.getPosition();
+        int c = ijRoi.getCPosition();
+        int z = ijRoi.getZPosition();
+        int t = ijRoi.getTPosition();
+        ij.ImagePlus ip = ij.WindowManager.getImage(ijRoi.getImageID()); //ijRoi.getImage() returns null
+        int imageC = ip.getNChannels();
+        int imageT = ip.getNFrames();
+        int imageZ = ip.getNSlices();
+        if (imageC == 1 && imageZ == 1) {
+            t = pos;
+            //reset values
+            c = 1;
+            z = 1;
+        } else if (imageZ == 1 && imageT == 1) {
+            c = pos;
+            //reset values
+            z = 1;
+            t = 1;
+        } else if (imageC == 1 && imageT == 1) {
+            z = pos;
+            //reset values
+            c = 1;
+            t = 1;
+        }
+        data.setC(Math.max(-1, c - 1));
+        data.setZ(Math.max(-1, z - 1));
+        data.setT(Math.max(-1, t - 1));
     }
 
 

--- a/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
@@ -150,9 +150,14 @@ public abstract class GenericShapeWrapper<T extends ShapeData> extends Annotatab
         int z = ijRoi.getZPosition();
         int t = ijRoi.getTPosition();
         ij.ImagePlus ip = ij.WindowManager.getImage(ijRoi.getImageID()); //ijRoi.getImage() returns null
-        int imageC = ip.getNChannels();
-        int imageT = ip.getNFrames();
-        int imageZ = ip.getNSlices();
+        int imageC = 1;
+        int imageT = 1;
+        int imageZ = 1;
+        if (ip != null) {
+            imageC = ip.getNChannels();
+            imageT = ip.getNFrames();
+            imageZ = ip.getNSlices();
+        }
         if (imageC == 1 && imageZ == 1) {
             t = pos;
             //reset values

--- a/src/test/java/fr/igred/omero/roi/ROI2ImageJTest.java
+++ b/src/test/java/fr/igred/omero/roi/ROI2ImageJTest.java
@@ -19,6 +19,8 @@ package fr.igred.omero.roi;
 
 
 import fr.igred.omero.BasicTest;
+import ij.IJ;
+import ij.ImagePlus;
 import ij.gui.Arrow;
 import ij.gui.EllipseRoi;
 import ij.gui.Line;
@@ -455,6 +457,78 @@ class ROI2ImageJTest extends BasicTest {
         assertEquals(polyline.getC(), newPolyline.getC());
         assertEquals(polyline.getZ(), newPolyline.getZ());
         assertEquals(polyline.getT(), newPolyline.getT());
+    }
+
+
+    @Test
+    void convertRectangleWithCStack() {
+        ImagePlus img = IJ.createImage("test", "grayscale", 1000, 1000, 10, 1, 1);
+        int pos = 4;
+        img.setPosition(pos);
+
+        Roi ijRoi = new Roi(10, 10, 10, 10);
+        ijRoi.setPosition(img);
+        ijRoi.setImage(img);
+
+        assertEquals(pos, ijRoi.getPosition());
+
+        List<Roi> roiList = new ArrayList<>(1);
+        roiList.add(ijRoi);
+        ROIWrapper roi = ROIWrapper.fromImageJ(roiList, null).get(0);
+
+        RectangleWrapper newRectangle = roi.getShapes().getElementsOf(RectangleWrapper.class).get(0);
+
+        assertEquals(pos - 1, newRectangle.getC());
+        assertEquals(0, newRectangle.getZ());
+        assertEquals(0, newRectangle.getT());
+    }
+
+
+    @Test
+    void convertRectangleWithZStack() {
+        ImagePlus img = IJ.createImage("test", "grayscale", 1000, 1000, 1, 10, 1);
+        int pos = 5;
+        img.setPosition(pos);
+
+        Roi ijRoi = new Roi(10, 10, 10, 10);
+        ijRoi.setPosition(img);
+        ijRoi.setImage(img);
+
+        assertEquals(pos, ijRoi.getPosition());
+
+        List<Roi> roiList = new ArrayList<>(1);
+        roiList.add(ijRoi);
+        ROIWrapper roi = ROIWrapper.fromImageJ(roiList, null).get(0);
+
+        RectangleWrapper newRectangle = roi.getShapes().getElementsOf(RectangleWrapper.class).get(0);
+
+        assertEquals(0, newRectangle.getC());
+        assertEquals(pos - 1, newRectangle.getZ());
+        assertEquals(0, newRectangle.getT());
+    }
+
+
+    @Test
+    void convertRectangleWithTStack() {
+        ImagePlus img = IJ.createImage("test", "grayscale", 1000, 1000, 1, 1, 10);
+        int pos = 6;
+        img.setPosition(pos);
+
+        Roi ijRoi = new Roi(10, 10, 10, 10);
+        ijRoi.setPosition(img);
+        ijRoi.setImage(img);
+
+        assertEquals(pos, ijRoi.getPosition());
+
+        List<Roi> roiList = new ArrayList<>(1);
+        roiList.add(ijRoi);
+        ROIWrapper roi = ROIWrapper.fromImageJ(roiList, null).get(0);
+
+        RectangleWrapper newRectangle = roi.getShapes().getElementsOf(RectangleWrapper.class).get(0);
+
+        assertEquals(0, newRectangle.getC());
+        assertEquals(0, newRectangle.getZ());
+        assertEquals(pos - 1, newRectangle.getT());
     }
 
 }


### PR DESCRIPTION
This PR fixes an issue when setting the plane associated to a given shape.
The current implementation does not handle images with for example ``t=1``, ``z=1`` and ``c>1``.
This is based on https://github.com/ome/omero-insight/blob/master/src/main/java/org/openmicroscopy/shoola/util/roi/io/ROIReader.java#L227
