### PR TITLE
List all groups on the OMERO database

### DIFF
--- a/src/main/java/fr/igred/omero/Client.java
+++ b/src/main/java/fr/igred/omero/Client.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -373,25 +374,22 @@ public class Client extends Browser {
 
 
     /**
-     * Returns all the groups on the OMERO database (for admins only)
+     * Returns all the groups on OMERO.
      *
-     * @return The list of groups on OMERO.
+     * @return See above.
      *
      * @throws ServiceException       Cannot connect to OMERO.
      * @throws AccessException        Cannot access data.
-     * @throws NoSuchElementException The requested group cannot be found.
      */
     public List<GroupWrapper> getGroups()
     throws ServiceException, AccessException {
         String error = "Cannot retrieve the groups on OMERO";
         return ExceptionHandler.of(getGateway(),
                                    g -> g.getAdminService(getCtx()).lookupGroups())
-                               .rethrow(ApiUsageException.class,
-                                        (m, e) -> new NoSuchElementException(m),
-                                        "Groups not found")
                                .handleOMEROException(error)
                                .get()
                                .stream()
+                               .filter(Objects::nonNull)
                                .map(GroupData::new)
                                .map(GroupWrapper::new)
                                .collect(Collectors.toList());

--- a/src/main/java/fr/igred/omero/Client.java
+++ b/src/main/java/fr/igred/omero/Client.java
@@ -371,32 +371,32 @@ public class Client extends Browser {
         return new GroupWrapper(new GroupData(group));
     }
 
+
     /**
      * Returns all the groups on the OMERO database (for admins only)
      *
      * @return The list of groups on OMERO.
      *
      * @throws ServiceException       Cannot connect to OMERO.
-     * @throws OMEROServerError       Server error.
      * @throws AccessException        Cannot access data.
      * @throws NoSuchElementException The requested group cannot be found.
-     * @throws ExecutionException     A Facility can't be retrieved or instantiated.
      */
     public List<GroupWrapper> getGroups()
-    throws ServiceException, OMEROServerError, AccessException, ExecutionException, NoSuchElementException {
-        if(getUser().isAdmin(this)) {
-            List<ExperimenterGroup> groups = ExceptionHandler.of(getGateway(),
-                                                          g -> g.getAdminService(getCtx()).lookupGroups())
-                                                      .rethrow(ApiUsageException.class,
-                                                               (m, e) -> new NoSuchElementException(m),
-                                                               "Groups not found")
-                                                      .handleServiceOrServer("Cannot retrieve the groups on OMERO")
-                                                      .get();
-            return groups.stream().map(GroupData::new).map(GroupWrapper::new).collect(Collectors.toList());
-        }else{
-            throw new NoSuchElementException("You don't have admin rights to get the list of all the groups on OMERO");
-        }
+    throws ServiceException, AccessException {
+        String error = "Cannot retrieve the groups on OMERO";
+        return ExceptionHandler.of(getGateway(),
+                                   g -> g.getAdminService(getCtx()).lookupGroups())
+                               .rethrow(ApiUsageException.class,
+                                        (m, e) -> new NoSuchElementException(m),
+                                        "Groups not found")
+                               .handleOMEROException(error)
+                               .get()
+                               .stream()
+                               .map(GroupData::new)
+                               .map(GroupWrapper::new)
+                               .collect(Collectors.toList());
     }
+
 
     /**
      * Gets the client associated with the username in the parameters. The user calling this function needs to have

--- a/src/main/java/fr/igred/omero/Client.java
+++ b/src/main/java/fr/igred/omero/Client.java
@@ -378,10 +378,12 @@ public class Client extends Browser {
      *
      * @throws ServiceException       Cannot connect to OMERO.
      * @throws OMEROServerError       Server error.
+     * @throws AccessException        Cannot access data.
      * @throws NoSuchElementException The requested group cannot be found.
+     * @throws ExecutionException     A Facility can't be retrieved or instantiated.
      */
     public List<GroupWrapper> getGroups()
-    throws ServiceException, OMEROServerError, AccessException, ExecutionException {
+    throws ServiceException, OMEROServerError, AccessException, ExecutionException, NoSuchElementException {
         if(getUser().isAdmin(this)) {
             List<ExperimenterGroup> groups = ExceptionHandler.of(getGateway(),
                                                           g -> g.getAdminService(getCtx()).lookupGroups())

--- a/src/main/java/fr/igred/omero/Client.java
+++ b/src/main/java/fr/igred/omero/Client.java
@@ -365,7 +365,7 @@ public class Client extends Browser {
         ExperimenterGroup group = ExceptionHandler.of(getGateway(), g -> g.getAdminService(getCtx()).getGroup(groupId))
                                                   .rethrow(ApiUsageException.class,
                                                            (m, e) -> new NoSuchElementException(m),
-                                                           "User not found: " + groupId)
+                                                           "Group not found: " + groupId)
                                                   .handleServiceOrServer("Cannot retrieve group: " + groupId)
                                                   .get();
         return new GroupWrapper(new GroupData(group));

--- a/src/main/java/fr/igred/omero/repository/ScreenWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/ScreenWrapper.java
@@ -50,11 +50,11 @@ public class ScreenWrapper extends GenericRepositoryObjectWrapper<ScreenData> {
 
 
     /**
-     * Constructor of the ProjectWrapper class. Creates a new project and saves it to OMERO.
+     * Constructor of the ScreenWrapper class. Creates a new screen and saves it to OMERO.
      *
      * @param client      The client handling the connection.
-     * @param name        Project name.
-     * @param description Project description.
+     * @param name        Screen name.
+     * @param description Screen description.
      *
      * @throws ServiceException   Cannot connect to OMERO.
      * @throws AccessException    Cannot access data.

--- a/src/test/java/fr/igred/omero/ClientTest.java
+++ b/src/test/java/fr/igred/omero/ClientTest.java
@@ -19,6 +19,7 @@ package fr.igred.omero;
 
 
 import fr.igred.omero.meta.ExperimenterWrapper;
+import fr.igred.omero.meta.GroupWrapper;
 import fr.igred.omero.repository.DatasetWrapper;
 import fr.igred.omero.repository.ImageWrapper;
 import fr.igred.omero.repository.PlateWrapper;
@@ -370,6 +371,13 @@ class ClientTest extends UserTest {
 
         Collection<WellWrapper> wells = client.getWells(user);
         assertEquals(0, wells.size());
+    }
+
+
+    @Test
+    void testGetAllGroups() throws Exception {
+        List<GroupWrapper> groups = client.getGroups();
+        assertEquals(7, groups.size());
     }
 
 }


### PR DESCRIPTION
Add a method to list all the groups on the current OMERO server. This method is restricted to admin people.