### PR TITLE
Add a return statement to the link methods

### DIFF
--- a/src/main/java/fr/igred/omero/repository/ImageWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/ImageWrapper.java
@@ -240,6 +240,15 @@ public class ImageWrapper extends GenericRepositoryObjectWrapper<ImageData> {
         return data.getAcquisitionDate();
     }
 
+    /**
+     * Gets the image original file format
+     *
+     * @return image format.
+     */
+    public String getFormat() {
+        return data.asImage().getFormat().getValue().getValue();
+    }
+
 
     /**
      * Returns the type of annotation link for this object.


### PR DESCRIPTION
The ``link`` methods were void methods. 
However, it would be better if they return the annotation ID instead of nothing so that we can use the result of the linking operation.