### PR TITLE
Add a font size setter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>fr.igred</groupId>
     <artifactId>simple-omero-client</artifactId>
-    <version>5.16.0</version>
+    <version>5.17.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Simple OMERO Client</name>

--- a/src/main/java/fr/igred/omero/roi/TextWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/TextWrapper.java
@@ -19,9 +19,14 @@ package fr.igred.omero.roi;
 
 
 import ij.gui.TextRoi;
+import ome.model.enums.UnitsLength;
 import omero.gateway.model.TextData;
+import omero.model.LengthI;
 
+import java.awt.Font;
+import java.awt.font.TextAttribute;
 import java.awt.geom.Path2D;
+import java.util.Map;
 
 
 /**
@@ -57,6 +62,12 @@ public class TextWrapper extends GenericShapeWrapper<TextData> {
     public TextWrapper(TextRoi text) {
         this(text.getText(), text.getBounds().getX(), text.getBounds().getY());
         super.copyFromIJRoi(text);
+        Font font = text.getCurrentFont();
+        if(font != null) {
+            Map<TextAttribute, ?> attributes = font.getAttributes();
+            if(attributes.containsKey(TextAttribute.SIZE) && attributes.get(TextAttribute.SIZE) != null)
+                setFontSize(((Float)(attributes.get(TextAttribute.SIZE))));
+        }
     }
 
 
@@ -93,6 +104,15 @@ public class TextWrapper extends GenericShapeWrapper<TextData> {
         data.setText(text);
     }
 
+    /**
+     * Sets the font size on the ShapeData.
+     *
+     * @param size the font size
+     */
+    public void setFontSize(int size) {
+        if(size > 0)
+           data.getShapeSettings().setFontSize(new LengthI(size, UnitsLength.POINT));
+    }
 
     /**
      * Converts the shape to an {@link java.awt.Shape}.


### PR DESCRIPTION
Hello @ppouchin, 

I noticed that there is no way to set the font size of a TextWrapper. I've just added a method to set it and, in case the ROI comes from ImageJ, I also extact this info in the dedicated constructor.

Thanks,
Rémy.

P.S: by the way, did you manage to find some time to look at the other PRs ?