### PR TITLE
Fix rois

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>fr.igred</groupId>
     <artifactId>simple-omero-client</artifactId>
-    <version>5.16.0</version>
+    <version>5.17.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Simple OMERO Client</name>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
             <id>ppouchin</id>
             <name>Pierre Pouchin</name>
             <email>pierre.pouchin@uca.fr</email>
-            <url>https://www.igred.fr/directory/member/pierre-pouchin/</url>
+            <url>https://www.igred.fr/en/member/pierre_pouchin/</url>
             <organization>GReD (INSERM U1103 / CNRS UMR 6293 / UCA)</organization>
             <organizationUrl>https://www.igred.fr</organizationUrl>
             <roles>

--- a/src/main/java/fr/igred/omero/AnnotatableWrapper.java
+++ b/src/main/java/fr/igred/omero/AnnotatableWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/Browser.java
+++ b/src/main/java/fr/igred/omero/Browser.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/Client.java
+++ b/src/main/java/fr/igred/omero/Client.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/GatewayWrapper.java
+++ b/src/main/java/fr/igred/omero/GatewayWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/GenericObjectWrapper.java
+++ b/src/main/java/fr/igred/omero/GenericObjectWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/annotations/AnnotationList.java
+++ b/src/main/java/fr/igred/omero/annotations/AnnotationList.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/annotations/FileAnnotationWrapper.java
+++ b/src/main/java/fr/igred/omero/annotations/FileAnnotationWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/annotations/GenericAnnotationWrapper.java
+++ b/src/main/java/fr/igred/omero/annotations/GenericAnnotationWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/annotations/MapAnnotationWrapper.java
+++ b/src/main/java/fr/igred/omero/annotations/MapAnnotationWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/annotations/RatingAnnotationWrapper.java
+++ b/src/main/java/fr/igred/omero/annotations/RatingAnnotationWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/annotations/TableWrapper.java
+++ b/src/main/java/fr/igred/omero/annotations/TableWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/annotations/TagAnnotationWrapper.java
+++ b/src/main/java/fr/igred/omero/annotations/TagAnnotationWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/annotations/TagSetWrapper.java
+++ b/src/main/java/fr/igred/omero/annotations/TagSetWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/annotations/TextualAnnotationWrapper.java
+++ b/src/main/java/fr/igred/omero/annotations/TextualAnnotationWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/annotations/package-info.java
+++ b/src/main/java/fr/igred/omero/annotations/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/exception/AccessException.java
+++ b/src/main/java/fr/igred/omero/exception/AccessException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/exception/ExceptionHandler.java
+++ b/src/main/java/fr/igred/omero/exception/ExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/exception/OMEROServerError.java
+++ b/src/main/java/fr/igred/omero/exception/OMEROServerError.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/exception/ServiceException.java
+++ b/src/main/java/fr/igred/omero/exception/ServiceException.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/exception/package-info.java
+++ b/src/main/java/fr/igred/omero/exception/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/meta/ExperimenterWrapper.java
+++ b/src/main/java/fr/igred/omero/meta/ExperimenterWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/meta/GroupWrapper.java
+++ b/src/main/java/fr/igred/omero/meta/GroupWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/meta/PlaneInfoWrapper.java
+++ b/src/main/java/fr/igred/omero/meta/PlaneInfoWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/meta/package-info.java
+++ b/src/main/java/fr/igred/omero/meta/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/package-info.java
+++ b/src/main/java/fr/igred/omero/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/repository/ChannelWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/ChannelWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/repository/DatasetWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/DatasetWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/repository/FolderWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/FolderWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/repository/GenericRepositoryObjectWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/GenericRepositoryObjectWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/repository/ImageWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/ImageWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/repository/PixelsWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/PixelsWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/repository/PlateAcquisitionWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/PlateAcquisitionWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/repository/PlateWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/PlateWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/repository/ProjectWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/ProjectWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/repository/ScreenWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/ScreenWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/repository/WellSampleWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/WellSampleWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/repository/WellWrapper.java
+++ b/src/main/java/fr/igred/omero/repository/WellWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/repository/package-info.java
+++ b/src/main/java/fr/igred/omero/repository/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/roi/EllipseWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/EllipseWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
@@ -64,7 +64,7 @@ public abstract class GenericShapeWrapper<T extends ShapeData> extends Annotatab
     public static final String ANNOTATION_LINK = "ShapeAnnotationLink";
 
     /** Default IJ property to store shape ID. */
-    static final String IJ_IDPROPERTY = "SHAPE_ID";
+    public static final String IJ_IDPROPERTY = "SHAPE_ID";
 
     /** Transparent color */
     private static final Color TRANSPARENT = new Color(0, 0, 0, 0);
@@ -254,7 +254,7 @@ public abstract class GenericShapeWrapper<T extends ShapeData> extends Annotatab
 
     /**
      * Copies details to an ImageJ ROI (name, position, stroke color, fill color, stroke width).
-     * <p>Also sets the "SHAPE_ID" property (using the shape ID).</p>
+     * <p>Also sets the {@code SHAPE_ID} property to the shape ID.</p>
      *
      * @param ijRoi An ImageJ Roi.
      */

--- a/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
@@ -23,6 +23,7 @@ import fr.igred.omero.Client;
 import fr.igred.omero.exception.AccessException;
 import fr.igred.omero.exception.ServiceException;
 import ij.ImagePlus;
+import ij.gui.ImageRoi;
 import ij.gui.Line;
 import ij.gui.Roi;
 import ij.gui.ShapeRoi;
@@ -126,6 +127,8 @@ public abstract class GenericShapeWrapper<T extends ShapeData> extends Annotatab
             default:
                 if (ijRoi instanceof TextRoi) {
                     list.add(new TextWrapper((TextRoi) ijRoi));
+                } else if (ijRoi instanceof ImageRoi) {
+                    list.add(new MaskWrapper((ImageRoi) ijRoi));
                 } else {
                     list.add(new RectangleWrapper(ijRoi));
                 }
@@ -256,7 +259,7 @@ public abstract class GenericShapeWrapper<T extends ShapeData> extends Annotatab
         ijRoi.setStrokeColor(getStroke());
         Color fill = getFill();
         if (!TRANSPARENT.equals(fill)) {
-            ijRoi.setFillColor(getFill());
+            ijRoi.setFillColor(fill);
         }
         int c = Math.max(0, getC() + 1);
         int z = Math.max(0, getZ() + 1);

--- a/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/GenericShapeWrapper.java
@@ -63,6 +63,9 @@ public abstract class GenericShapeWrapper<T extends ShapeData> extends Annotatab
     /** Annotation link name for this type of object */
     public static final String ANNOTATION_LINK = "ShapeAnnotationLink";
 
+    /** Default IJ property to store shape ID. */
+    static final String IJ_IDPROPERTY = "SHAPE_ID";
+
     /** Transparent color */
     private static final Color TRANSPARENT = new Color(0, 0, 0, 0);
 
@@ -251,6 +254,7 @@ public abstract class GenericShapeWrapper<T extends ShapeData> extends Annotatab
 
     /**
      * Copies details to an ImageJ ROI (name, position, stroke color, fill color, stroke width).
+     * <p>Also sets the "SHAPE_ID" property (using the shape ID).</p>
      *
      * @param ijRoi An ImageJ Roi.
      */
@@ -268,6 +272,7 @@ public abstract class GenericShapeWrapper<T extends ShapeData> extends Annotatab
         if (ijRoi instanceof TextRoi) {
             copyToIJTextRoi((TextRoi) ijRoi);
         }
+        ijRoi.setProperty(IJ_IDPROPERTY, String.valueOf(data.getId()));
     }
 
 

--- a/src/main/java/fr/igred/omero/roi/LineWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/LineWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/roi/MaskWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/MaskWrapper.java
@@ -18,11 +18,15 @@
 package fr.igred.omero.roi;
 
 
+import ij.gui.ImageRoi;
 import ij.gui.Roi;
+import ij.process.ImageProcessor;
 import omero.gateway.model.MaskData;
 
+import java.awt.Color;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
 
 
 /**
@@ -30,6 +34,9 @@ import java.awt.geom.Rectangle2D;
  * <p> Wraps function calls to the MaskData contained.
  */
 public class MaskWrapper extends GenericShapeWrapper<MaskData> {
+
+
+    private static final double MAX_UINT8 = 255.0;
 
 
     /**
@@ -47,6 +54,41 @@ public class MaskWrapper extends GenericShapeWrapper<MaskData> {
      */
     public MaskWrapper() {
         this(new MaskData());
+    }
+
+
+    /**
+     * Constructor of the MaskWrapper class using an ImageJ ImageRoi.
+     *
+     * @param imageRoi An ImageJ ImageRoi.
+     */
+    public MaskWrapper(ImageRoi imageRoi) {
+        this();
+        data.setX(imageRoi.getXBase());
+        data.setY(imageRoi.getYBase());
+        data.setWidth(imageRoi.getFloatWidth());
+        data.setHeight(imageRoi.getFloatHeight());
+
+        ImageProcessor ip = imageRoi.getProcessor();
+        ip.flipVertical();
+        data.setMask(ip.getIntArray());
+        ip.flipVertical();
+
+        Color lut = new Color(ip.getCurrentColorModel().getRGB((int) ip.getMax()));
+        int   r   = lut.getRed();
+        int   g   = lut.getGreen();
+        int   b   = lut.getBlue();
+        int   a   = (int) (imageRoi.getOpacity() * MAX_UINT8);
+
+        data.setText(imageRoi.getName());
+        super.copyFromIJRoi(imageRoi);
+        data.getShapeSettings().setFill(new Color(r, g, b, a));
+
+        // Always 0 as long as ImageRoi::getAngle() method is not updated
+        double          angle     = StrictMath.toRadians(-imageRoi.getAngle());
+        AffineTransform transform = new AffineTransform();
+        transform.rotate(angle, imageRoi.getXBase(), imageRoi.getYBase());
+        super.setTransform(transform);
     }
 
 
@@ -188,6 +230,16 @@ public class MaskWrapper extends GenericShapeWrapper<MaskData> {
 
 
     /**
+     * Returns the mask image.
+     *
+     * @return See above.
+     */
+    public BufferedImage getMaskAsBufferedImage() {
+        return data.getMaskAsBufferedImage();
+    }
+
+
+    /**
      * Returns the mask as a byte array.
      *
      * @return See above.
@@ -288,7 +340,12 @@ public class MaskWrapper extends GenericShapeWrapper<MaskData> {
 
         Roi roi;
         if (transform.getType() == AffineTransform.TYPE_IDENTITY) {
-            roi = new ij.gui.Roi(getX(), getY(), getWidth(), getHeight());
+            int      x      = (int) getX();
+            int      y      = (int) getY();
+            ImageRoi imgRoi = new ImageRoi(x, y, getMaskAsBufferedImage());
+            imgRoi.setZeroTransparent(true);
+            imgRoi.setOpacity(getFill().getAlpha() / MAX_UINT8);
+            roi = imgRoi;
         } else {
             PointWrapper p1 = new PointWrapper(getX(), getY() + getHeight() / 2);
             PointWrapper p2 = new PointWrapper(getX() + getWidth(), getY() + getHeight() / 2);

--- a/src/main/java/fr/igred/omero/roi/MaskWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/MaskWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/roi/PointWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/PointWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/roi/PolygonWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/PolygonWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/roi/PolylineWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/PolylineWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/roi/ROIWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/ROIWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/roi/ROIWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/ROIWrapper.java
@@ -279,12 +279,18 @@ public class ROIWrapper extends AnnotatableWrapper<ROIData> {
 
     /**
      * Combines a list of ROIs into a single ROI.
+     * <p>{@code SHAPE_ID} property is the concatenation of shape IDs.</p>
      *
      * @param rois The ROIs to combine (must contain at least 1 element).
      *
      * @return See above.
      */
     private static ij.gui.Roi xor(Collection<? extends ij.gui.Roi> rois) {
+        String idProperty = GenericShapeWrapper.IJ_IDPROPERTY;
+        String shapeIDs = rois.stream()
+                              .map(r -> r.getProperty(idProperty))
+                              .collect(Collectors.joining(","));
+
         ij.gui.Roi roi = rois.iterator().next();
         if (rois.size() > 1) {
             ij.gui.Roi xor = rois.stream()
@@ -296,10 +302,7 @@ public class ROIWrapper extends AnnotatableWrapper<ROIData> {
             xor.setFillColor(roi.getFillColor());
             xor.setPosition(roi.getCPosition(), roi.getZPosition(), roi.getTPosition());
             xor.setName(roi.getName());
-
-            String shapeID = roi.getProperty(GenericShapeWrapper.IJ_IDPROPERTY);
-            xor.setProperty(GenericShapeWrapper.IJ_IDPROPERTY, shapeID);
-
+            xor.setProperty(idProperty, shapeIDs);
             roi = xor;
         }
         return roi;
@@ -314,10 +317,16 @@ public class ROIWrapper extends AnnotatableWrapper<ROIData> {
      * @return See above.
      */
     private static PointRoi combine(Collection<? extends PointRoi> points) {
+        String idProperty = GenericShapeWrapper.IJ_IDPROPERTY;
+        String shapeIDs = points.stream()
+                                .map(p -> p.getProperty(idProperty))
+                                .collect(Collectors.joining(","));
+
         PointRoi point = points.iterator().next();
         points.stream()
               .skip(1)
               .forEachOrdered(p -> point.addPoint(p.getXBase(), p.getYBase()));
+        point.setProperty(idProperty, shapeIDs);
         return point;
     }
 

--- a/src/main/java/fr/igred/omero/roi/RectangleWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/RectangleWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/roi/ShapeList.java
+++ b/src/main/java/fr/igred/omero/roi/ShapeList.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/roi/TextWrapper.java
+++ b/src/main/java/fr/igred/omero/roi/TextWrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/roi/package-info.java
+++ b/src/main/java/fr/igred/omero/roi/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/util/LibraryChecker.java
+++ b/src/main/java/fr/igred/omero/util/LibraryChecker.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/util/Wrapper.java
+++ b/src/main/java/fr/igred/omero/util/Wrapper.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/main/java/fr/igred/omero/util/package-info.java
+++ b/src/main/java/fr/igred/omero/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/BasicTest.java
+++ b/src/test/java/fr/igred/omero/BasicTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/ClientTest.java
+++ b/src/test/java/fr/igred/omero/ClientTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/ConnectionTest.java
+++ b/src/test/java/fr/igred/omero/ConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/LoggingExtension.java
+++ b/src/test/java/fr/igred/omero/LoggingExtension.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/RootTest.java
+++ b/src/test/java/fr/igred/omero/RootTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/SudoTest.java
+++ b/src/test/java/fr/igred/omero/SudoTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/TestObject.java
+++ b/src/test/java/fr/igred/omero/TestObject.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/UserTest.java
+++ b/src/test/java/fr/igred/omero/UserTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/annotations/ImageJTableTest.java
+++ b/src/test/java/fr/igred/omero/annotations/ImageJTableTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/annotations/MapAnnotationTest.java
+++ b/src/test/java/fr/igred/omero/annotations/MapAnnotationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/annotations/RatingAnnotationTest.java
+++ b/src/test/java/fr/igred/omero/annotations/RatingAnnotationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/annotations/TableTest.java
+++ b/src/test/java/fr/igred/omero/annotations/TableTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/annotations/TagSetTest.java
+++ b/src/test/java/fr/igred/omero/annotations/TagSetTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/annotations/TagTest.java
+++ b/src/test/java/fr/igred/omero/annotations/TagTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/annotations/TextualAnnotationTest.java
+++ b/src/test/java/fr/igred/omero/annotations/TextualAnnotationTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/exception/AccessExceptionTest.java
+++ b/src/test/java/fr/igred/omero/exception/AccessExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/exception/ExceptionTest.java
+++ b/src/test/java/fr/igred/omero/exception/ExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/meta/ExperimenterTest.java
+++ b/src/test/java/fr/igred/omero/meta/ExperimenterTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/meta/GroupTest.java
+++ b/src/test/java/fr/igred/omero/meta/GroupTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/meta/PlaneInfoWrapperTest.java
+++ b/src/test/java/fr/igred/omero/meta/PlaneInfoWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/repository/ChannelTest.java
+++ b/src/test/java/fr/igred/omero/repository/ChannelTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/repository/DatasetTest.java
+++ b/src/test/java/fr/igred/omero/repository/DatasetTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/repository/FolderTest.java
+++ b/src/test/java/fr/igred/omero/repository/FolderTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/repository/ImageImportTest.java
+++ b/src/test/java/fr/igred/omero/repository/ImageImportTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/repository/ImageTest.java
+++ b/src/test/java/fr/igred/omero/repository/ImageTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/repository/PixelsTest.java
+++ b/src/test/java/fr/igred/omero/repository/PixelsTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/repository/PlateAcquisitionTest.java
+++ b/src/test/java/fr/igred/omero/repository/PlateAcquisitionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/repository/PlateTest.java
+++ b/src/test/java/fr/igred/omero/repository/PlateTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/repository/ProjectTest.java
+++ b/src/test/java/fr/igred/omero/repository/ProjectTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/repository/ScreenTest.java
+++ b/src/test/java/fr/igred/omero/repository/ScreenTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/repository/WellSampleTest.java
+++ b/src/test/java/fr/igred/omero/repository/WellSampleTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/repository/WellTest.java
+++ b/src/test/java/fr/igred/omero/repository/WellTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/roi/ROI2ImageJTest.java
+++ b/src/test/java/fr/igred/omero/roi/ROI2ImageJTest.java
@@ -31,6 +31,8 @@ import ij.gui.Roi;
 import ij.gui.ShapeRoi;
 import ij.gui.TextRoi;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.awt.Color;
 import java.awt.Font;
@@ -38,7 +40,6 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -46,7 +47,6 @@ import java.util.regex.Pattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 class ROI2ImageJTest extends BasicTest {
@@ -403,9 +403,10 @@ class ROI2ImageJTest extends BasicTest {
     }
 
 
-    @Test
-    void convertText2() {
-        Font font = new Font("Arial", Font.BOLD, 25);
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(ints = {Font.PLAIN, Font.BOLD, Font.ITALIC, Font.BOLD | Font.ITALIC})
+    void convertText(int style) {
+        Font font = new Font("Arial", style, 25);
         List<Roi> roiList = new ArrayList<>(1);
         TextRoi   ijText  = new TextRoi(3, 3, "Text");
         ijText.setAngle(33);

--- a/src/test/java/fr/igred/omero/roi/ROI2ImageJTest.java
+++ b/src/test/java/fr/igred/omero/roi/ROI2ImageJTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/roi/ROI2ImageJTest.java
+++ b/src/test/java/fr/igred/omero/roi/ROI2ImageJTest.java
@@ -33,16 +33,20 @@ import ij.gui.TextRoi;
 import org.junit.jupiter.api.Test;
 
 import java.awt.Color;
+import java.awt.Font;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 class ROI2ImageJTest extends BasicTest {
@@ -396,6 +400,29 @@ class ROI2ImageJTest extends BasicTest {
         assertEquals(text.getZ(), newText.getZ());
         assertEquals(text.getT(), newText.getT());
         assertEquals(text.getText(), c.matcher(newText.getText().trim()).replaceAll(Matcher.quoteReplacement("")));
+    }
+
+
+    @Test
+    void convertText2() {
+        Font font = new Font("Arial", Font.BOLD, 25);
+        List<Roi> roiList = new ArrayList<>(1);
+        TextRoi   ijText  = new TextRoi(3, 3, "Text");
+        ijText.setAngle(33);
+        ijText.setFont(font);
+        roiList.add(ijText);
+
+        Roi ijRoi = ROIWrapper.toImageJ(ROIWrapper.fromImageJ(roiList)).get(0);
+
+        assertInstanceOf(TextRoi.class, ijRoi);
+        assertEquals(ijText.getXBase(), ijRoi.getXBase(), Double.MIN_VALUE);
+        assertEquals(ijText.getYBase(), ijRoi.getYBase(), Double.MIN_VALUE);
+        assertEquals(ijText.getAngle(), ijRoi.getAngle(), Double.MIN_VALUE);
+
+        Font newFont = ((TextRoi) ijRoi).getCurrentFont();
+        assertEquals(font.getFamily(), newFont.getFamily());
+        assertEquals(font.getStyle(), newFont.getStyle());
+        assertEquals(font.getSize(), newFont.getSize());
     }
 
 

--- a/src/test/java/fr/igred/omero/roi/ROITest.java
+++ b/src/test/java/fr/igred/omero/roi/ROITest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/roi/ShapeErrorTest.java
+++ b/src/test/java/fr/igred/omero/roi/ShapeErrorTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/roi/ShapeTest.java
+++ b/src/test/java/fr/igred/omero/roi/ShapeTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/util/LibraryCheckerTest.java
+++ b/src/test/java/fr/igred/omero/util/LibraryCheckerTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/src/test/java/fr/igred/omero/util/WrapperTest.java
+++ b/src/test/java/fr/igred/omero/util/WrapperTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2020-2023 GReD
+ *  Copyright (C) 2020-2024 GReD
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
This should improve how masks and text ROIs are handled.

Moreover, now, only 2D ROIs (rectangles, polygons and ellipses) are XORed when converted to ImageJ (provided they're on the exact same plane).
Points are simply combined and others ROIs are kept separate.
This is to prevent a useless conversion to 2D for 0D/1D shapes (or masks, which hold more information).

A new property has been added to IJ Rois: "SHAPE_ID", which contains the shape ID. 
If multiple shapes were combined, it contains a list of IDs (separated by commas).