### PR TITLE
Re-assign correct indices to emptyColumns at table creation

### DIFF
--- a/src/main/java/fr/igred/omero/annotations/TableWrapper.java
+++ b/src/main/java/fr/igred/omero/annotations/TableWrapper.java
@@ -881,8 +881,10 @@ public class TableWrapper {
             truncateRow();
         }
 
-        Collection<Integer> emptyColumns = getEmptyStringColumns();
-        emptyColumns.forEach(this::removeColumn);
+        ArrayList<Integer> emptyColumns = new ArrayList<>(getEmptyStringColumns());
+        for(int i = 0; i <emptyColumns.size(); i++){
+            removeColumn(emptyColumns.get(i)-i);
+        }
 
         return new TableData(columns, data);
     }

--- a/src/main/java/fr/igred/omero/annotations/TableWrapper.java
+++ b/src/main/java/fr/igred/omero/annotations/TableWrapper.java
@@ -42,6 +42,7 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -516,7 +517,7 @@ public class TableWrapper {
      */
     private Collection<Integer> getEmptyStringColumns() {
         Collection<Integer> emptyColumns = new ArrayList<>(0);
-        for (int j = 0; j < columns.length; j++) {
+        for (int j = columns.length - 1; j >= 0; j--) {
             TableDataColumn column = columns[j];
             if (column.getType().equals(String.class)) {
                 boolean empty = true;
@@ -881,10 +882,9 @@ public class TableWrapper {
             truncateRow();
         }
 
-        ArrayList<Integer> emptyColumns = new ArrayList<>(getEmptyStringColumns());
-        for(int i = 0; i <emptyColumns.size(); i++){
-            removeColumn(emptyColumns.get(i)-i);
-        }
+        List<Integer> emptyColumns = new ArrayList<>(getEmptyStringColumns());
+        emptyColumns.sort(Collections.reverseOrder());
+        emptyColumns.forEach(this::removeColumn);
 
         return new TableData(columns, data);
     }

--- a/src/test/java/fr/igred/omero/annotations/TableTest.java
+++ b/src/test/java/fr/igred/omero/annotations/TableTest.java
@@ -62,9 +62,58 @@ class TableTest extends UserTest {
         }
 
         assertEquals(images.get(0).asDataObject(), table.getData(0, 0));
-        assertEquals(images.get(1).getName(), table.getData(0, 1));
+        assertEquals(images.get(1).getName(), table.getData(1, 1));
 
         dataset.addTable(client, table);
+
+        List<TableWrapper> tables = dataset.getTables(client);
+        client.deleteTables(tables);
+        List<TableWrapper> noTables = dataset.getTables(client);
+
+        assertEquals(1, tables.size());
+        assertEquals(0, noTables.size());
+    }
+
+
+    @Test
+    void testCreateTableWithEmptyColumns() throws Exception {
+        DatasetWrapper dataset = client.getDataset(DATASET1.id);
+
+        List<ImageWrapper> images = dataset.getImages(client);
+
+        TableWrapper table = new TableWrapper(4, "TableTest");
+
+        assertEquals(4, table.getColumnCount());
+
+        table.setColumn(0, "Image", ImageData.class);
+        table.setColumn(1, "Condition", String.class);
+        table.setColumn(2, "Name", String.class);
+        table.setColumn(3, "Phenotype", String.class);
+        assertEquals("Image", table.getColumnName(0));
+        assertEquals("Condition", table.getColumnName(1));
+        assertEquals("Name", table.getColumnName(2));
+        assertEquals("Phenotype", table.getColumnName(3));
+        assertSame(ImageData.class, table.getColumnType(0));
+
+        table.setRowCount(images.size());
+
+        assertEquals(images.size(), table.getRowCount());
+
+        for (ImageWrapper image : images) {
+            assertFalse(table.isComplete());
+            table.addRow(image.asDataObject(), "", image.getName(), "");
+        }
+
+        assertEquals(images.get(0).asDataObject(), table.getData(0, 0));
+        assertEquals("", table.getData(0, 1));
+        assertEquals(images.get(1).getName(), table.getData(1, 2));
+        assertEquals("", table.getData(0, 3));
+
+        dataset.addTable(client, table);
+
+        assertEquals(2, table.getColumnCount());
+        assertEquals(images.get(0).asDataObject(), table.getData(0, 0));
+        assertEquals(images.get(1).getName(), table.getData(1, 1));
 
         List<TableWrapper> tables = dataset.getTables(client);
         client.deleteTables(tables);


### PR DESCRIPTION
Hello @ppouchin 

In some cases, when multiple columns have to be removed from a TableWrapper object, because they are considered as empty columns, wrong columns are removed instead.
I found out that because of the re-indexing performed in [this method](https://github.com/GReD-Clermont/simple-omero-client/blob/main/src/main/java/fr/igred/omero/annotations/TableWrapper.java#L544), the [next indices](https://github.com/GReD-Clermont/simple-omero-client/blob/main/src/main/java/fr/igred/omero/annotations/TableWrapper.java#L885) to remove are not correct anymore and it removes the wrong columns (only the first column to remove is correct)

To correct it, I simply subtract the number of columns already removed in the table to the next indices.

Rémy.