### PR TITLE
Do not use Double.MIN_VALUE as delta for comparing doubles.

### DIFF
--- a/src/test/java/fr/igred/omero/annotations/ImageJTableTest.java
+++ b/src/test/java/fr/igred/omero/annotations/ImageJTableTest.java
@@ -168,7 +168,7 @@ class ImageJTableTest extends UserTest {
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(roiId, ((DataObject) data[1][0]).getId());
         assertEquals(label, data[2][0]);
-        assertEquals(VOLUME1, (Double) data[3][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[3][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[4][0]);
         assertEquals(label, data[5][0]);
         assertNotNull(fileId);
@@ -202,7 +202,7 @@ class ImageJTableTest extends UserTest {
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(roiId, ((DataObject) data[1][0]).getId());
         assertEquals(label, data[2][0]);
-        assertEquals(VOLUME1, (Double) data[3][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[3][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[4][0]);
         assertEquals(label, data[5][0]);
         assertEquals(label, data[6][0]);
@@ -234,7 +234,7 @@ class ImageJTableTest extends UserTest {
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(roiId, ((DataObject) data[1][0]).getId());
         assertEquals(label, data[2][0]);
-        assertEquals(VOLUME1, (Double) data[3][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[3][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[4][0]);
         assertNotNull(fileId);
     }
@@ -263,7 +263,7 @@ class ImageJTableTest extends UserTest {
         assertEquals(1, rowCount);
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(roiId, ((DataObject) data[1][0]).getId());
-        assertEquals(VOLUME1, (Double) data[2][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[2][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[3][0]);
         assertEquals(label, data[4][0]);
         assertNotNull(fileId);
@@ -291,7 +291,7 @@ class ImageJTableTest extends UserTest {
 
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(label, data[1][0]);
-        assertEquals(VOLUME1, (Double) data[2][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[2][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[3][0]);
         assertEquals(0, noTables.size());
     }
@@ -321,11 +321,11 @@ class ImageJTableTest extends UserTest {
 
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(label, data[1][0]);
-        assertEquals(VOLUME1, (Double) data[2][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[2][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[3][0]);
         assertEquals(IMAGE_ID, ((DataObject) data[0][1]).getId());
         assertEquals(label, data[1][1]);
-        assertEquals(VOLUME2, (Double) data[2][1], Double.MIN_VALUE);
+        assertEquals(VOLUME2, (Double) data[2][1], DOUBLE_PRECISION);
         assertEquals(UNIT2, data[3][1]);
         assertEquals(0, noTables.size());
     }
@@ -359,12 +359,12 @@ class ImageJTableTest extends UserTest {
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(roiId, ((DataObject) data[1][0]).getId());
         assertEquals(label, data[2][0]);
-        assertEquals(VOLUME1, (Double) data[3][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[3][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[4][0]);
         assertEquals(IMAGE_ID, ((DataObject) data[0][1]).getId());
         assertEquals(roiId, ((DataObject) data[1][1]).getId());
         assertEquals(label, data[2][1]);
-        assertEquals(VOLUME2, (Double) data[3][1], Double.MIN_VALUE);
+        assertEquals(VOLUME2, (Double) data[3][1], DOUBLE_PRECISION);
         assertEquals(UNIT2, data[4][1]);
         assertNotNull(fileId);
     }
@@ -398,12 +398,12 @@ class ImageJTableTest extends UserTest {
         assertEquals(2, rowCount);
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(label, data[1][0]);
-        assertEquals(VOLUME1, (Double) data[2][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[2][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[3][0]);
         assertEquals(local.getName(), data[4][0]);
         assertEquals(IMAGE_ID, ((DataObject) data[0][1]).getId());
         assertEquals(label, data[1][1]);
-        assertEquals(VOLUME2, (Double) data[2][1], Double.MIN_VALUE);
+        assertEquals(VOLUME2, (Double) data[2][1], DOUBLE_PRECISION);
         assertEquals(UNIT2, data[3][1]);
         assertEquals(ijRois.get(0).getName(), data[4][1]);
         assertNotNull(fileId);
@@ -437,11 +437,11 @@ class ImageJTableTest extends UserTest {
         assertEquals(2, rowCount);
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(label1, data[1][0]);
-        assertEquals(VOLUME1, (Double) data[2][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[2][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[3][0]);
         assertEquals(IMAGE_ID, ((DataObject) data[0][1]).getId());
         assertEquals(label2, data[1][1]);
-        assertEquals(VOLUME2, (Double) data[2][1], Double.MIN_VALUE);
+        assertEquals(VOLUME2, (Double) data[2][1], DOUBLE_PRECISION);
         assertEquals(UNIT2, data[3][1]);
         assertNotNull(fileId);
     }
@@ -497,12 +497,12 @@ class ImageJTableTest extends UserTest {
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(newROIs.get(0).getId(), ((DataObject) data[1][0]).getId());
         assertEquals(label1, data[2][0]);
-        assertEquals(VOLUME1, (Double) data[3][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[3][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[4][0]);
         assertEquals(IMAGE_ID, ((DataObject) data[0][1]).getId());
         assertEquals(newROIs.get(1).getId(), ((DataObject) data[1][1]).getId());
         assertEquals(label2, data[2][1]);
-        assertEquals(VOLUME2, (Double) data[3][1], Double.MIN_VALUE);
+        assertEquals(VOLUME2, (Double) data[3][1], DOUBLE_PRECISION);
         assertEquals(UNIT2, data[4][1]);
         assertNotNull(fileId);
     }
@@ -560,12 +560,12 @@ class ImageJTableTest extends UserTest {
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(rois.get(0).getId(), ((DataObject) data[1][0]).getId());
         assertEquals(label1, data[2][0]);
-        assertEquals(VOLUME1, (Double) data[3][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[3][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[4][0]);
         assertEquals(IMAGE_ID, ((DataObject) data[0][1]).getId());
         assertEquals(rois.get(1).getId(), ((DataObject) data[1][1]).getId());
         assertEquals(label2, data[2][1]);
-        assertEquals(VOLUME2, (Double) data[3][1], Double.MIN_VALUE);
+        assertEquals(VOLUME2, (Double) data[3][1], DOUBLE_PRECISION);
         assertEquals(UNIT2, data[4][1]);
         assertNotNull(fileId);
     }
@@ -620,7 +620,7 @@ class ImageJTableTest extends UserTest {
         assertEquals(1, rowCount);
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(label, data[1][0]);
-        assertEquals(VOLUME1, (Double) data[2][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[2][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[3][0]);
         assertEquals(label, data[4][0]);
         assertEquals(1.0, data[5][0]);
@@ -652,7 +652,7 @@ class ImageJTableTest extends UserTest {
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(rois.get(0).getId(), ((DataObject) data[1][0]).getId());
         assertEquals(label, data[2][0]);
-        assertEquals(VOLUME1, (Double) data[3][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[3][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[4][0]);
         assertEquals(label, data[5][0]);
         assertNotNull(fileId);
@@ -687,11 +687,11 @@ class ImageJTableTest extends UserTest {
 
         assertEquals(IMAGE_ID, ((DataObject) data[0][0]).getId());
         assertEquals(label, data[1][0]);
-        assertEquals(VOLUME1, (Double) data[2][0], Double.MIN_VALUE);
+        assertEquals(VOLUME1, (Double) data[2][0], DOUBLE_PRECISION);
         assertEquals(UNIT1, data[3][0]);
         assertEquals(IMAGE_ID, ((DataObject) data[0][1]).getId());
         assertEquals(label, data[1][1]);
-        assertEquals(Double.NaN, (Double) data[2][1], Double.MIN_VALUE);
+        assertEquals(Double.NaN, (Double) data[2][1], DOUBLE_PRECISION);
         assertEquals("50", data[3][1]);
         assertEquals(0, noTables.size());
     }

--- a/src/test/java/fr/igred/omero/core/ImageTest.java
+++ b/src/test/java/fr/igred/omero/core/ImageTest.java
@@ -379,9 +379,9 @@ class ImageTest extends UserTest {
         ImagePlus       difference = calculator.run("difference create stack", crop, imp);
         ImageStatistics stats      = difference.getStatistics();
 
-        assertEquals(pixSize, imp.getCalibration().pixelHeight, Double.MIN_VALUE);
-        assertEquals(pixSize, imp.getCalibration().pixelWidth, Double.MIN_VALUE);
-        assertEquals(pixDepth, imp.getCalibration().pixelDepth, Double.MIN_VALUE);
+        assertEquals(pixSize, imp.getCalibration().pixelHeight, DOUBLE_PRECISION);
+        assertEquals(pixSize, imp.getCalibration().pixelWidth, DOUBLE_PRECISION);
+        assertEquals(pixDepth, imp.getCalibration().pixelDepth, DOUBLE_PRECISION);
         // Round numbers because rounding errors happen when converting units
         assertEquals(deltaT, imp.getCalibration().frameInterval, DOUBLE_PRECISION * deltaT);
         assertEquals(xOrigin, imp.getCalibration().xOrigin, DOUBLE_PRECISION * abs(xOrigin));

--- a/src/test/java/fr/igred/omero/roi/ROI2ImageJTest.java
+++ b/src/test/java/fr/igred/omero/roi/ROI2ImageJTest.java
@@ -231,10 +231,10 @@ class ROI2ImageJTest extends BasicTest {
 
         EllipseWrapper newEllipse = roi.getShapes().getElementsOf(EllipseWrapper.class).get(0);
 
-        assertEquals(ellipse.getX(), newEllipse.getX(), Double.MIN_VALUE);
-        assertEquals(ellipse.getY(), newEllipse.getY(), Double.MIN_VALUE);
-        assertEquals(ellipse.getRadiusX(), newEllipse.getRadiusX(), Double.MIN_VALUE);
-        assertEquals(ellipse.getRadiusY(), newEllipse.getRadiusY(), Double.MIN_VALUE);
+        assertEquals(ellipse.getX(), newEllipse.getX(), DOUBLE_PRECISION);
+        assertEquals(ellipse.getY(), newEllipse.getY(), DOUBLE_PRECISION);
+        assertEquals(ellipse.getRadiusX(), newEllipse.getRadiusX(), DOUBLE_PRECISION);
+        assertEquals(ellipse.getRadiusY(), newEllipse.getRadiusY(), DOUBLE_PRECISION);
         assertEquals(ellipse.getC(), newEllipse.getC());
         assertEquals(ellipse.getZ(), newEllipse.getZ());
         assertEquals(ellipse.getT(), newEllipse.getT());
@@ -255,10 +255,10 @@ class ROI2ImageJTest extends BasicTest {
 
         RectangleWrapper newRectangle = roi.getShapes().getElementsOf(RectangleWrapper.class).get(0);
 
-        assertEquals(rectangle.getX(), newRectangle.getX(), Double.MIN_VALUE);
-        assertEquals(rectangle.getY(), newRectangle.getY(), Double.MIN_VALUE);
-        assertEquals(rectangle.getWidth(), newRectangle.getWidth(), Double.MIN_VALUE);
-        assertEquals(rectangle.getHeight(), newRectangle.getHeight(), Double.MIN_VALUE);
+        assertEquals(rectangle.getX(), newRectangle.getX(), DOUBLE_PRECISION);
+        assertEquals(rectangle.getY(), newRectangle.getY(), DOUBLE_PRECISION);
+        assertEquals(rectangle.getWidth(), newRectangle.getWidth(), DOUBLE_PRECISION);
+        assertEquals(rectangle.getHeight(), newRectangle.getHeight(), DOUBLE_PRECISION);
         assertEquals(rectangle.getC(), newRectangle.getC());
         assertEquals(rectangle.getZ(), newRectangle.getZ());
         assertEquals(rectangle.getT(), newRectangle.getT());
@@ -273,10 +273,10 @@ class ROI2ImageJTest extends BasicTest {
         arrow.setFill(new Color(0, 0, 0, 0));
 
         Arrow ijArrow = (Arrow) arrow.toImageJ();
-        assertEquals(arrow.getX1(), ijArrow.x2d, Double.MIN_VALUE);
-        assertEquals(arrow.getY1(), ijArrow.y2d, Double.MIN_VALUE);
-        assertEquals(arrow.getX2(), ijArrow.x1d, Double.MIN_VALUE);
-        assertEquals(arrow.getY2(), ijArrow.y1d, Double.MIN_VALUE);
+        assertEquals(arrow.getX1(), ijArrow.x2d, DOUBLE_PRECISION);
+        assertEquals(arrow.getY1(), ijArrow.y2d, DOUBLE_PRECISION);
+        assertEquals(arrow.getX2(), ijArrow.x1d, DOUBLE_PRECISION);
+        assertEquals(arrow.getY2(), ijArrow.y1d, DOUBLE_PRECISION);
         assertNull(ijArrow.getFillColor());
 
         List<Roi> roiList = new ArrayList<>(1);
@@ -285,10 +285,10 @@ class ROI2ImageJTest extends BasicTest {
 
         LineWrapper newArrow = roi.getShapes().getElementsOf(LineWrapper.class).get(0);
 
-        assertEquals(arrow.getX1(), newArrow.getX2(), Double.MIN_VALUE);
-        assertEquals(arrow.getY1(), newArrow.getY2(), Double.MIN_VALUE);
-        assertEquals(arrow.getX2(), newArrow.getX1(), Double.MIN_VALUE);
-        assertEquals(arrow.getY2(), newArrow.getY1(), Double.MIN_VALUE);
+        assertEquals(arrow.getX1(), newArrow.getX2(), DOUBLE_PRECISION);
+        assertEquals(arrow.getY1(), newArrow.getY2(), DOUBLE_PRECISION);
+        assertEquals(arrow.getX2(), newArrow.getX1(), DOUBLE_PRECISION);
+        assertEquals(arrow.getY2(), newArrow.getY1(), DOUBLE_PRECISION);
         assertEquals(arrow.getC(), newArrow.getC());
         assertEquals(arrow.getZ(), newArrow.getZ());
         assertEquals(arrow.getT(), newArrow.getT());
@@ -304,10 +304,10 @@ class ROI2ImageJTest extends BasicTest {
         line.setFill(Color.BLUE);
 
         Line ijLine = (Line) line.toImageJ();
-        assertEquals(line.getX1(), ijLine.x1d, Double.MIN_VALUE);
-        assertEquals(line.getY1(), ijLine.y1d, Double.MIN_VALUE);
-        assertEquals(line.getX2(), ijLine.x2d, Double.MIN_VALUE);
-        assertEquals(line.getY2(), ijLine.y2d, Double.MIN_VALUE);
+        assertEquals(line.getX1(), ijLine.x1d, DOUBLE_PRECISION);
+        assertEquals(line.getY1(), ijLine.y1d, DOUBLE_PRECISION);
+        assertEquals(line.getX2(), ijLine.x2d, DOUBLE_PRECISION);
+        assertEquals(line.getY2(), ijLine.y2d, DOUBLE_PRECISION);
         assertEquals(Color.BLUE, line.getFill());
 
         List<Roi> roiList = new ArrayList<>(1);
@@ -316,10 +316,10 @@ class ROI2ImageJTest extends BasicTest {
 
         LineWrapper newLine = roi.getShapes().getElementsOf(LineWrapper.class).get(0);
 
-        assertEquals(line.getX1(), newLine.getX1(), Double.MIN_VALUE);
-        assertEquals(line.getY1(), newLine.getY1(), Double.MIN_VALUE);
-        assertEquals(line.getX2(), newLine.getX2(), Double.MIN_VALUE);
-        assertEquals(line.getY2(), newLine.getY2(), Double.MIN_VALUE);
+        assertEquals(line.getX1(), newLine.getX1(), DOUBLE_PRECISION);
+        assertEquals(line.getY1(), newLine.getY1(), DOUBLE_PRECISION);
+        assertEquals(line.getX2(), newLine.getX2(), DOUBLE_PRECISION);
+        assertEquals(line.getY2(), newLine.getY2(), DOUBLE_PRECISION);
         assertEquals(line.getC(), newLine.getC());
         assertEquals(line.getZ(), newLine.getZ());
         assertEquals(line.getT(), newLine.getT());
@@ -353,10 +353,10 @@ class ROI2ImageJTest extends BasicTest {
         MaskWrapper newMask   = roi.getShapes().getElementsOf(MaskWrapper.class).get(0);
         int[][]     checkMask = newMask.getMaskAsBinaryArray();
 
-        assertEquals(mask.getX(), newMask.getX(), Double.MIN_VALUE);
-        assertEquals(mask.getY(), newMask.getY(), Double.MIN_VALUE);
-        assertEquals(mask.getWidth(), newMask.getWidth(), Double.MIN_VALUE);
-        assertEquals(mask.getHeight(), newMask.getHeight(), Double.MIN_VALUE);
+        assertEquals(mask.getX(), newMask.getX(), DOUBLE_PRECISION);
+        assertEquals(mask.getY(), newMask.getY(), DOUBLE_PRECISION);
+        assertEquals(mask.getWidth(), newMask.getWidth(), DOUBLE_PRECISION);
+        assertEquals(mask.getHeight(), newMask.getHeight(), DOUBLE_PRECISION);
         assertEquals(mask.getC(), newMask.getC());
         assertEquals(mask.getZ(), newMask.getZ());
         assertEquals(mask.getT(), newMask.getT());
@@ -375,8 +375,8 @@ class ROI2ImageJTest extends BasicTest {
         point.setCZT(0, 0, 2);
 
         PointRoi ijPoint = (PointRoi) point.toImageJ();
-        assertEquals(point.getX(), ijPoint.getXBase(), Double.MIN_VALUE);
-        assertEquals(point.getY(), ijPoint.getYBase(), Double.MIN_VALUE);
+        assertEquals(point.getX(), ijPoint.getXBase(), DOUBLE_PRECISION);
+        assertEquals(point.getY(), ijPoint.getYBase(), DOUBLE_PRECISION);
 
         List<Roi> roiList = new ArrayList<>(1);
         roiList.add(ijPoint);
@@ -384,8 +384,8 @@ class ROI2ImageJTest extends BasicTest {
 
         PointWrapper newPoint = roi.getShapes().getElementsOf(PointWrapper.class).get(0);
 
-        assertEquals(point.getX(), newPoint.getX(), Double.MIN_VALUE);
-        assertEquals(point.getY(), newPoint.getY(), Double.MIN_VALUE);
+        assertEquals(point.getX(), newPoint.getX(), DOUBLE_PRECISION);
+        assertEquals(point.getY(), newPoint.getY(), DOUBLE_PRECISION);
         assertEquals(point.getC(), newPoint.getC());
         assertEquals(point.getZ(), newPoint.getZ());
         assertEquals(point.getT(), newPoint.getT());
@@ -403,8 +403,8 @@ class ROI2ImageJTest extends BasicTest {
         text.setCZT(0, 0, 2);
 
         TextRoi ijPoint = (TextRoi) text.toImageJ();
-        assertEquals(text.getX(), ijPoint.getXBase(), Double.MIN_VALUE);
-        assertEquals(text.getY(), ijPoint.getYBase(), Double.MIN_VALUE);
+        assertEquals(text.getX(), ijPoint.getXBase(), DOUBLE_PRECISION);
+        assertEquals(text.getY(), ijPoint.getYBase(), DOUBLE_PRECISION);
         assertEquals(text.getText(), c.matcher(ijPoint.getText().trim()).replaceAll(Matcher.quoteReplacement("")));
 
         List<Roi> roiList = new ArrayList<>(1);
@@ -413,8 +413,8 @@ class ROI2ImageJTest extends BasicTest {
 
         TextWrapper newText = roi.getShapes().getElementsOf(TextWrapper.class).get(0);
 
-        assertEquals(text.getX(), newText.getX(), Double.MIN_VALUE);
-        assertEquals(text.getY(), newText.getY(), Double.MIN_VALUE);
+        assertEquals(text.getX(), newText.getX(), DOUBLE_PRECISION);
+        assertEquals(text.getY(), newText.getY(), DOUBLE_PRECISION);
         assertEquals(text.getC(), newText.getC());
         assertEquals(text.getZ(), newText.getZ());
         assertEquals(text.getT(), newText.getT());
@@ -438,9 +438,9 @@ class ROI2ImageJTest extends BasicTest {
         Roi ijRoi = ROIWrapper.toImageJ(ROIWrapper.fromImageJ(roiList)).get(0);
 
         assertInstanceOf(TextRoi.class, ijRoi);
-        assertEquals(ijText.getXBase(), ijRoi.getXBase(), Double.MIN_VALUE);
-        assertEquals(ijText.getYBase(), ijRoi.getYBase(), Double.MIN_VALUE);
-        assertEquals(ijText.getAngle(), ijRoi.getAngle(), Double.MIN_VALUE);
+        assertEquals(ijText.getXBase(), ijRoi.getXBase(), DOUBLE_PRECISION);
+        assertEquals(ijText.getYBase(), ijRoi.getYBase(), DOUBLE_PRECISION);
+        assertEquals(ijText.getAngle(), ijRoi.getAngle(), DOUBLE_PRECISION);
 
         Font newFont = ((TextRoi) ijRoi).getCurrentFont();
         assertEquals(font.getFamily(), newFont.getFamily());

--- a/src/test/java/fr/igred/omero/roi/ShapeTest.java
+++ b/src/test/java/fr/igred/omero/roi/ShapeTest.java
@@ -62,7 +62,7 @@ class ShapeTest extends BasicTest {
             differences += abs(checkCoordinates[i] - pointCoordinates[i]);
         }
 
-        assertEquals(0, differences, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
         assertEquals(text, point.getText());
     }
 
@@ -88,8 +88,8 @@ class ShapeTest extends BasicTest {
             differences += abs(checkCoordinates[i] - textCoordinates[i]);
         }
 
-        assertEquals(0, differences, Double.MIN_VALUE);
-        assertEquals(font, fontSize, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
+        assertEquals(font, fontSize, DOUBLE_PRECISION);
         assertEquals(value, text.getText());
     }
 
@@ -108,7 +108,7 @@ class ShapeTest extends BasicTest {
             differences += abs(checkCoordinates[i] - rectangleCoordinates[i]);
         }
 
-        assertEquals(0, differences, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
     }
 
 
@@ -140,7 +140,7 @@ class ShapeTest extends BasicTest {
         int t2 = rectangle.getT();
         differences += abs(c2 - c) + abs(z2 - z) + abs(t2 - t);
 
-        assertEquals(0, differences, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
         assertEquals(text, rectangle.getText());
     }
 
@@ -159,7 +159,7 @@ class ShapeTest extends BasicTest {
             differences += abs(checkCoordinates[i] - maskCoordinates[i]);
         }
 
-        assertEquals(0, differences, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
     }
 
 
@@ -216,7 +216,7 @@ class ShapeTest extends BasicTest {
             differences += abs(checkCoordinates[i] - ellipseCoordinates[i]);
         }
 
-        assertEquals(0, differences, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
         assertEquals(stroke, ellipse.getStroke());
         assertEquals(fill, ellipse.getFill());
         assertEquals(text, ellipse.getText());
@@ -242,7 +242,7 @@ class ShapeTest extends BasicTest {
             differences += abs(checkCoordinates[i] - lineCoordinates[i]);
         }
 
-        assertEquals(0, differences, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
         assertEquals(text, line.getText());
     }
 
@@ -264,7 +264,7 @@ class ShapeTest extends BasicTest {
             differences += abs(checkCoordinates[i] - lineCoordinates[i]);
         }
 
-        assertEquals(0, differences, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
     }
 
 
@@ -329,7 +329,7 @@ class ShapeTest extends BasicTest {
             differences += abs(coordinates1[i] - coordinates2[i]);
         }
 
-        assertEquals(0, differences, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
     }
 
 
@@ -349,7 +349,7 @@ class ShapeTest extends BasicTest {
             differences += abs(coordinates1[i] - coordinates2[i]);
         }
 
-        assertEquals(0, differences, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
         assertEquals(text1.getText(), text2.getText());
     }
 
@@ -370,7 +370,7 @@ class ShapeTest extends BasicTest {
             differences += abs(coordinates1[i] - coordinates2[i]);
         }
 
-        assertEquals(0, differences, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
     }
 
 
@@ -390,7 +390,7 @@ class ShapeTest extends BasicTest {
             differences += abs(coordinates1[i] - coordinates2[i]);
         }
 
-        assertEquals(0, differences, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
     }
 
 
@@ -419,7 +419,7 @@ class ShapeTest extends BasicTest {
             differences += abs(checkValues2[i] - checkValues1[i]);
         }
 
-        assertEquals(0, differences, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
     }
 
 
@@ -439,7 +439,7 @@ class ShapeTest extends BasicTest {
             differences += abs(coordinates1[i] - coordinates2[i]);
         }
 
-        assertEquals(0, differences, Double.MIN_VALUE);
+        assertEquals(0, differences, DOUBLE_PRECISION);
     }
 
 
@@ -549,8 +549,8 @@ class ShapeTest extends BasicTest {
             double[] pos1 = new double[2];
             double[] pos2 = new double[2];
             assertEquals(pi.currentSegment(pos1), pi.currentSegment(pos2));
-            assertEquals(pos1[0], pos2[0], Double.MIN_VALUE);
-            assertEquals(pos1[1], pos2[1], Double.MIN_VALUE);
+            assertEquals(pos1[0], pos2[0], DOUBLE_PRECISION);
+            assertEquals(pos1[1], pos2[1], DOUBLE_PRECISION);
             pi.next();
             pi2.next();
         }
@@ -585,8 +585,8 @@ class ShapeTest extends BasicTest {
             double[] pos1 = new double[2];
             double[] pos2 = new double[2];
             assertEquals(pi.currentSegment(pos1), pi.currentSegment(pos2));
-            assertEquals(pos1[0], pos2[0], Double.MIN_VALUE);
-            assertEquals(pos1[1], pos2[1], Double.MIN_VALUE);
+            assertEquals(pos1[0], pos2[0], DOUBLE_PRECISION);
+            assertEquals(pos1[1], pos2[1], DOUBLE_PRECISION);
             pi.next();
             pi2.next();
         }
@@ -609,8 +609,8 @@ class ShapeTest extends BasicTest {
             double[] pos1 = new double[2];
             double[] pos2 = new double[2];
             assertEquals(pi.currentSegment(pos1), pi.currentSegment(pos2));
-            assertEquals(pos1[0], pos2[0], Double.MIN_VALUE);
-            assertEquals(pos1[1], pos2[1], Double.MIN_VALUE);
+            assertEquals(pos1[0], pos2[0], DOUBLE_PRECISION);
+            assertEquals(pos1[1], pos2[1], DOUBLE_PRECISION);
             pi.next();
             pi2.next();
         }
@@ -633,8 +633,8 @@ class ShapeTest extends BasicTest {
             double[] pos1 = new double[2];
             double[] pos2 = new double[2];
             assertEquals(pi.currentSegment(pos1), pi.currentSegment(pos2));
-            assertEquals(pos1[0], pos2[0], Double.MIN_VALUE);
-            assertEquals(pos1[1], pos2[1], Double.MIN_VALUE);
+            assertEquals(pos1[0], pos2[0], DOUBLE_PRECISION);
+            assertEquals(pos1[1], pos2[1], DOUBLE_PRECISION);
             pi.next();
             pi2.next();
         }
@@ -675,7 +675,7 @@ class ShapeTest extends BasicTest {
         double[] coordinates2 = shape.getBoundingBox().getCoordinates();
 
         for (int i = 0; i < 4; i++) {
-            assertEquals(coordinates1[i], coordinates2[i], Double.MIN_VALUE);
+            assertEquals(coordinates1[i], coordinates2[i], DOUBLE_PRECISION);
         }
     }
 
@@ -689,7 +689,7 @@ class ShapeTest extends BasicTest {
         double[] coordinates2 = shape.getBoundingBox().getCoordinates();
 
         for (int i = 0; i < 4; i++) {
-            assertEquals(coordinates1[i], coordinates2[i], Double.MIN_VALUE);
+            assertEquals(coordinates1[i], coordinates2[i], DOUBLE_PRECISION);
         }
     }
 

--- a/src/test/java/fr/igred/omero/screen/PlateTest.java
+++ b/src/test/java/fr/igred/omero/screen/PlateTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import static java.lang.Double.MIN_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -222,7 +221,7 @@ class PlateTest extends UserTest {
     void testGetWellOriginX() throws Exception {
         final double origin = 0.0d;
         PlateWrapper plate  = client.getPlate(PLATE1.id);
-        assertEquals(origin, plate.getWellOriginX(null).getValue(), MIN_VALUE);
+        assertEquals(origin, plate.getWellOriginX(null).getValue(), DOUBLE_PRECISION);
     }
 
 
@@ -230,7 +229,7 @@ class PlateTest extends UserTest {
     void testGetWellOriginY() throws Exception {
         final double origin = 1.0d;
         PlateWrapper plate  = client.getPlate(PLATE1.id);
-        assertEquals(origin, plate.getWellOriginY(null).getValue(), MIN_VALUE);
+        assertEquals(origin, plate.getWellOriginY(null).getValue(), DOUBLE_PRECISION);
     }
 
 

--- a/src/test/java/fr/igred/omero/screen/WellSampleTest.java
+++ b/src/test/java/fr/igred/omero/screen/WellSampleTest.java
@@ -100,7 +100,7 @@ class WellSampleTest extends UserTest {
         WellWrapper well = client.getWells(1L).get(0);
 
         WellSampleWrapper sample = well.getWellSamples().get(0);
-        assertEquals(0.0, sample.getPositionX(null).getValue(), Double.MIN_VALUE);
+        assertEquals(0.0, sample.getPositionX(null).getValue(), DOUBLE_PRECISION);
     }
 
 
@@ -109,7 +109,7 @@ class WellSampleTest extends UserTest {
         WellWrapper well = client.getWells(1L).get(0);
 
         WellSampleWrapper sample = well.getWellSamples().get(0);
-        assertEquals(1.0, sample.getPositionY(null).getValue(), Double.MIN_VALUE);
+        assertEquals(1.0, sample.getPositionY(null).getValue(), DOUBLE_PRECISION);
     }
 
 


### PR DESCRIPTION
`Double.MIN_VALUE` is not suitable as the "delta" value for comparing two doubles, because it is extremely small and may very well be smaller than the difference that may be expected due to the imprecise representation of floating point numbers. This happens at least under _some_ versions of Java (such as Java11, as reported in #94).

This PR replaces all uses of Double.MIN_VALUE in assertions comparing doubles by the `DOUBLE_PRECISION` constant defined in the `BasicTest` class (which is presumably exactly intended for that usage).